### PR TITLE
added symbols and geopoints functions

### DIFF
--- a/arkimapslib/mixer.py
+++ b/arkimapslib/mixer.py
@@ -236,6 +236,25 @@ class Mixer:
             self.parts.append(self.macro.mcoast(**params))
             self.py_lines.append(f"parts.append(macro.mcoast(**{params!r}))")
 
+    def add_symbols(self):
+        """
+        Add symbols settings
+        """
+        self.parts.append(self.macro.msymb(
+            symbol_type="marker",
+            symbol_marker_index=15,
+            legend="off",
+            symbol_colour="black",
+            symbol_height=0.28,
+        ))
+            
+    def add_geopoints(self, params: Optional[Kwargs] = None):
+        """
+        Add geopoint file
+        """
+        if params is not None:
+            self.parts.append(self.macro.mgeo(**params))          
+
     def serve(self):
         """
         Render the file and store the output file name into the order

--- a/recipes/litota3_nord.md
+++ b/recipes/litota3_nord.md
@@ -1,0 +1,149 @@
+# litota3_nord: Averaged total lightning flash density in the last 3 hours
+
+Mixer: **default**
+
+## Inputs
+
+* **litota3_nord**:
+    * **Arkimet matcher**: `product:GRIB2,98,0,17,4,5`
+    * **grib_filter matcher**: `shortName is "litota3"`
+
+## Steps
+
+### add_basemap
+
+Add a base map
+
+With arguments:
+```
+{
+  "params": {
+    "page_id_line": false,
+    "output_width": 900,
+    "page_y_length": 19.0,
+    "subpage_map_projection": "polar_stereographic",
+    "subpage_lower_left_longitude": 6.0,
+    "subpage_lower_left_latitude": 42.5,
+    "subpage_upper_right_longitude": 18.0,
+    "subpage_upper_right_latitude": 48.0,
+    "subpage_map_vertical_longitude": 10.3,
+    "map_grid": true,
+    "map_grid_latitude_reference": 45.0,
+    "map_grid_longitude_reference": 0.0,
+    "map_grid_longitude_increment": 1.0,
+    "map_grid_latitude_increment": 1.0,
+    "map_grid_colour": "grey",
+    "map_grid_line_style": "dash",
+    "map_label_colour": "black",
+    "map_label_height": 0.4,
+    "map_label_latitude_frequency": 1
+  }
+}
+```
+
+### add_coastlines_bg
+
+Add background coastlines
+
+
+### add_grib
+
+Add a grib file
+
+With arguments:
+```
+{
+  "name": "litota3_nord"
+}
+```
+
+### add_contour
+
+Add contouring of the previous data
+
+With arguments:
+```
+{
+  "params": {
+    "contour": false,
+    "contour_shade": true,
+    "contour_shade_method": "area_fill",
+    "contour_level_selection_type": "level_list",
+    "contour_level_list": [
+      0.1,
+      0.5,
+      1.0,
+      2.0,
+      5.0,
+      10.0,
+      20.0,
+      50.0,
+      100.0
+    ],
+    "contour_shade_colour_method": "list",
+    "contour_shade_colour_list": [
+      "#CC97A1",
+      "#610B1D",
+      "#A90528",
+      "#FF032F",
+      "#FF7126",
+      "#FFA12D",
+      "#FFDA37",
+      "#FDFC3F"
+    ],
+    "contour_highlight": false,
+    "contour_hilo": false,
+    "legend": true,
+    "legend_title": true,
+    "legend_title_text": "Averaged total lightning in the last 3h",
+    "legend_display_type": "continuous",
+    "legend_automatic_position": "right",
+    "legend_text_colour": "black",
+    "legend_title_font_size": 0.5
+  }
+}
+```
+
+### add_coastlines_fg
+
+Add foreground coastlines
+
+
+### add_grid
+
+Add a coordinates grid
+
+
+### add_boundaries
+
+Add a coordinates grid
+
+With arguments:
+```
+{
+  "params": {
+    "map_user_layer": true,
+    "map_user_layer_name": "/usr/local/share/libsim-1.1/Sottozone_allerta_ER",
+    "map_user_layer_colour": "blue"
+  }
+}
+```
+
+### add_geopoints
+
+Add geopoint file
+
+With arguments:
+```
+{
+  "params": {
+    "geo_input_file_name": "/tmp/puntiCitta.geo"
+  }
+}
+```
+
+### add_symbols
+
+Add symbols settings
+
+

--- a/recipes/litota3_nord.yaml
+++ b/recipes/litota3_nord.yaml
@@ -1,0 +1,63 @@
+---
+# https://confluence.ecmwf.int/pages/viewpage.action?pageId=106611144
+description: Averaged total lightning flash density in the last 3 hours
+inputs:
+ litota3_nord:
+  - model: any
+    arkimet: product:GRIB2,98,0,17,4,5
+    eccodes: shortName is "litota3"
+recipe:
+ - step: add_basemap
+   params: 
+    page_id_line: off
+    output_width: 900
+    page_y_length: 19.0
+    subpage_map_projection: polar_stereographic
+    subpage_lower_left_longitude: 6.0
+    subpage_lower_left_latitude: 42.5
+    subpage_upper_right_longitude: 18.0
+    subpage_upper_right_latitude: 48.0
+    subpage_map_vertical_longitude: 10.3
+    map_grid: on
+    map_grid_latitude_reference: 45.0 
+    map_grid_longitude_reference: 0.0
+    map_grid_longitude_increment: 1.0
+    map_grid_latitude_increment: 1.0
+    map_grid_colour: grey
+    map_grid_line_style: dash
+    map_label_colour: black
+    map_label_height: 0.4
+    map_label_latitude_frequency : 1
+ - step: add_coastlines_bg
+ - step: add_grib
+   name: litota3_nord
+ - step: add_contour
+   params:
+    contour: off
+    contour_shade: on
+    contour_shade_method: area_fill
+    contour_level_selection_type: level_list
+    contour_level_list: [0.1, 0.5, 1.0, 2.0, 5.0, 10.0 ,20.0, 50.0, 100.0]
+    contour_shade_colour_method: list
+    contour_shade_colour_list: [ "#CC97A1", "#610B1D", "#A90528",
+            "#FF032F", "#FF7126", "#FFA12D", "#FFDA37", "#FDFC3F" ]
+    contour_highlight: off
+    contour_hilo: off
+    legend: on
+    legend_title: on
+    legend_title_text: 'Averaged total lightning in the last 3h'
+    legend_display_type: continuous
+    legend_automatic_position: right
+    legend_text_colour: black
+    legend_title_font_size: 0.5
+ - step: add_coastlines_fg
+ - step: add_grid
+ - step: add_boundaries
+   params:
+    map_user_layer: on
+    map_user_layer_name: "/usr/local/share/libsim-1.1/Sottozone_allerta_ER"
+    map_user_layer_colour: blue
+ - step: add_geopoints
+   params:
+    geo_input_file_name: "/tmp/puntiCitta.geo"
+ - step: add_symbols


### PR DESCRIPTION
Proposta da sviluppare, nel dettagli:
- `add_symbols` al momento ha dei default blindati, idealmente potrebbe dare la possibilità di sostituirli come avviene per il contouring
- la ricetta di test aggiunta (`litota3_nord.yaml`) potrebbe tuonare in fase di test visto che usa uno shapefile e dei geopoint con un path assoluto, come si diceva in altre sedi sarebbe carino poter identificare un path nei sorgenti dove parcheggiare alcuni elementi geografici comuni (anche in modo da poterli infilare nei test) -  Edit: che è poi lo stesso tema della #60 