### PR TITLE
Allow unit in model steps (refs #154)

### DIFF
--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -83,6 +83,12 @@ class Instant:
     def __str__(self):
         return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self.step}"
 
+    def step_is_zero(self) -> bool:
+        """
+        Return True if the step is zero
+        """
+        return self._step == 0
+
     def pantry_suffix(self) -> str:
         """
         Return a suffix that identifies a product for this instance in the
@@ -888,7 +894,7 @@ class GroundToMSL(GribSetMixin, Derived):
 
         z_input: InputFile
         for instant, input_file in pantry.get_instants(self.inputs[0]).items():
-            if instant.step != 0:
+            if not instant.step_is_zero():
                 log.warning("input %s: ignoring input %s with step %d instead of 0",
                             self.name, input_file.info.name, instant.step)
             z_input = input_file

--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -60,11 +60,16 @@ class Instant:
         self._step = step
 
     @property
-    def reftime(self):
+    def reftime(self) -> datetime.datetime:
+        """
+        Access the model reference time.
+        """
         return self._reftime
 
     @property
     def step(self):
+        import warnings
+        warnings.warn("Do not access step directly", DeprecationWarning, stacklevel=2)
         return self._step
 
     def __eq__(self, other):
@@ -79,11 +84,26 @@ class Instant:
         return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self.step}"
 
     def pantry_suffix(self) -> str:
-        return (f"_{self.reftime.year}_{self.reftime.month}_{self.reftime.day}"
-                f"_{self.reftime.hour}_{self.reftime.minute}_{self.reftime.second}+{self.step}")
+        """
+        Return a suffix that identifies a product for this instance in the
+        pantry
+        """
+        return (f"_{self._reftime.year}_{self._reftime.month}_{self._reftime.day}"
+                f"_{self._reftime.hour}_{self._reftime.minute}_{self._reftime.second}"
+                f"+{self._step}")
 
     def product_suffix(self) -> str:
-        return (f"_{self.reftime:%Y-%m-%dT%H:%M:%S}+{self.step:03d}")
+        """
+        Return a suffix that identifies a product for this instance in the
+        output
+        """
+        return f"_{self.reftime:%Y-%m-%dT%H:%M:%S}{self.step_suffix()}"
+
+    def step_suffix(self) -> str:
+        """
+        Return a suffix that can be used in filenames to identify a step
+        """
+        return f"+{self._step:03d}"
 
 
 class InputTypes(TypeRegistry["Input"]):

--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -89,6 +89,22 @@ class Instant:
         """
         return self._step == 0
 
+    def step_is(self, val: str) -> bool:
+        """
+        Return True if the step matches the given value.
+
+        The value has a time unit suffix. Currently supported:
+
+        * ``h``: hours
+        """
+        if not isinstance(val, str):
+            raise TypeError(f"val {val!r} is not a string")
+        if len(val) < 2:
+            raise ValueError(f"val {val!r} is too short to be a number plus unit suffix")
+        if val[-1] != 'h':
+            raise ValueError(f"unsupported time unit suffx: {val[-1]!r}")
+        return self._step == int(val[:-1])
+
     def pantry_suffix(self) -> str:
         """
         Return a suffix that identifies a product for this instance in the

--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -81,7 +81,7 @@ class Instant:
         return hash((self._reftime, self._step))
 
     def __str__(self):
-        return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self.step}"
+        return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self._step}"
 
     def step_is_zero(self) -> bool:
         """
@@ -895,8 +895,8 @@ class GroundToMSL(GribSetMixin, Derived):
         z_input: InputFile
         for instant, input_file in pantry.get_instants(self.inputs[0]).items():
             if not instant.step_is_zero():
-                log.warning("input %s: ignoring input %s with step %d instead of 0",
-                            self.name, input_file.info.name, instant.step)
+                log.warning("input %s: ignoring input %s with step %s instead of 0",
+                            self.name, input_file.info.name, instant.step_suffix())
             z_input = input_file
             break
         else:

--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -128,36 +128,19 @@ class Instant:
 
     @property
     def step(self):
-        import warnings
-        warnings.warn("Do not access step directly", DeprecationWarning, stacklevel=2)
-        return self._step._value
+        return self._step
 
     def __eq__(self, other):
-        if not isinstance(other, Instant):
+        if isinstance(other, Instant):
+            return self._reftime == other._reftime and self._step == other._step
+        else:
             return NotImplemented
-        return self._reftime == other._reftime and self._step == other._step
 
     def __hash__(self) -> int:
         return hash((self._reftime, self._step))
 
     def __str__(self):
-        return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self._step._value}"
-
-    def step_is_zero(self) -> bool:
-        """
-        Return True if the step is zero
-        """
-        return self._step.is_zero()
-
-    def step_is(self, val: Union[int, str, ModelStep]) -> bool:
-        """
-        Return True if the step matches the given value.
-
-        The value has a time unit suffix. Currently supported:
-
-        * ``h``: hours
-        """
-        return self._step == val
+        return f"{self._reftime:%Y-%m-%dT%H:%M:%S}+{self._step._value}"
 
     def pantry_suffix(self) -> str:
         """
@@ -964,7 +947,7 @@ class GroundToMSL(GribSetMixin, Derived):
 
         z_input: InputFile
         for instant, input_file in pantry.get_instants(self.inputs[0]).items():
-            if not instant.step_is_zero():
+            if not instant.step.is_zero():
                 log.warning("input %s: ignoring input %s with step %s instead of 0",
                             self.name, input_file.info.name, instant.step_suffix())
             z_input = input_file

--- a/arkimapslib/inputs.py
+++ b/arkimapslib/inputs.py
@@ -43,15 +43,37 @@ def keep_only_first_grib(fname: str):
             eccodes.codes_release(gid)
 
 
-class Instant(NamedTuple):
+class Instant:
     """
     Identifies an instant of time for which we have data for an input.
 
     Note that different combinations of reftime+step that would map to the same
     physical instant of time are considered distinct for arkimaps purposes
     """
-    reftime: datetime.datetime
-    step: int
+    __slots__ = ("_reftime", "_step")
+
+    _reftime: datetime.datetime
+    _step: int
+
+    def __init__(self, reftime: datetime.datetime, step: int):
+        self._reftime = reftime
+        self._step = step
+
+    @property
+    def reftime(self):
+        return self._reftime
+
+    @property
+    def step(self):
+        return self._step
+
+    def __eq__(self, other):
+        if not isinstance(other, Instant):
+            return NotImplemented
+        return self._reftime == other._reftime and self._step == other._step
+
+    def __hash__(self) -> int:
+        return hash((self._reftime, self._step))
 
     def __str__(self):
         return f"{self.reftime:%Y-%m-%dT%H:%M:%S}+{self.step}"

--- a/arkimapslib/kitchen.py
+++ b/arkimapslib/kitchen.py
@@ -16,6 +16,7 @@ from .config import Config
 from .flavours import Flavour
 from .lint import Lint
 from .recipes import Recipe
+from .inputs import ModelStep
 
 # if TYPE_CHECKING:
 # Used for kwargs-style dicts
@@ -160,7 +161,7 @@ class WorkingKitchen(Kitchen):
             self,
             recipe: Recipe,
             flavour: Flavour,
-            step: Optional[int],
+            step: Union[None, int, str, ModelStep],
             reftime: Optional[datetime.datetime]) -> orders.Order:
         """
         Generate all possible orders for all available recipes

--- a/arkimapslib/orders.py
+++ b/arkimapslib/orders.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, NamedTuple, Option
 from PIL import Image
 
 from . import outputbundle
+from .inputs import ModelStep
 from .steps import StepSkipped, StepConfig, AddBasemap
 from .pygen import PyGen
 
@@ -194,12 +195,12 @@ class Order:
 
             for reftime, orders in by_rt.items():
                 inputs: Set[str] = set()
-                steps: dict[int, int] = Counter()
+                steps: dict[str, int] = Counter()
                 legend_info: Optional[Dict[str, Any]] = None
                 render_time_ns: int = 0
                 for order in orders:
                     inputs.update(order.input_files.keys())
-                    steps[order.instant.step] += 1
+                    steps[str(order.instant.step)] += 1
                     if order.legend_info:
                         legend_info = order.legend_info
                     render_time_ns += order.render_time_ns

--- a/arkimapslib/orders.py
+++ b/arkimapslib/orders.py
@@ -241,10 +241,10 @@ class MapOrder(Order):
             self.order_steps.append(s)
 
     def __str__(self):
-        return f"{os.path.basename(self.recipe.name)}+{self.instant.step:03d}"
+        return f"{os.path.basename(self.recipe.name)}{self.instant.step_suffix()}"
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({os.path.basename(self.recipe.name)}+{self.instant.step:03d})"
+        return f"{self.__class__.__name__}({os.path.basename(self.recipe.name)}{self.instant.step_suffix()})"
 
     def print_python_function(self, function_name: str, gen: PyGen):
         """
@@ -350,7 +350,7 @@ class TileOrder(Order):
             self.order_steps.append(compiled_step)
 
     def __str__(self):
-        return (f"{os.path.basename(self.recipe.name)}+{self.instant.step:03d}/"
+        return (f"{os.path.basename(self.recipe.name)}{self.instant.step_suffix()}/"
                 f"{self.z}/{self.x}/{self.y}+w{self.width}h{self.height}")
 
     def __repr__(self):
@@ -362,7 +362,7 @@ class TileOrder(Order):
         """
         relpath = (
             f"{self.instant.reftime:%Y-%m-%dT%H:%M:%S}/"
-            f"{self.recipe.name}_{self.flavour.name}+{self.instant.step:03d}/"
+            f"{self.recipe.name}_{self.flavour.name}{self.instant.step_suffix()}/"
             f"{self.z}"
         )
         basename = f"{self.x}-{self.y}-{self.width}-{self.height}"
@@ -549,7 +549,7 @@ class LegendOrder(Order):
         }
 
     def __str__(self):
-        return f"{os.path.basename(self.recipe.name)}+{self.instant.step:03d}/legend"
+        return f"{os.path.basename(self.recipe.name)}{self.instant.step_suffix()}/legend"
 
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)})"

--- a/arkimapslib/orders.py
+++ b/arkimapslib/orders.py
@@ -253,7 +253,7 @@ class MapOrder(Order):
         # Destination directory inside the output
         relpath = f"{self.instant.reftime:%Y-%m-%dT%H:%M:%S}/{self.recipe.name}_{self.flavour.name}"
         # Destination file name (without path or .png extension)
-        basename = f"{os.path.basename(self.recipe.name)}+{self.instant.step:03d}"
+        basename = f"{os.path.basename(self.recipe.name)}{self.instant.step_suffix()}"
         gen.magics_renderer(function_name, self, relpath, basename)
 
 

--- a/tests/test_cp3h.py
+++ b/tests/test_cp3h.py
@@ -14,7 +14,7 @@ class CP3HMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "cp3h" and o.instant.step == 12]
+        orders = [o for o in orders if o.recipe.name == "cp3h" and o.instant.step_is("12h")]
         self.assertEqual(len(orders), 1)
 
         self.assertRenders(orders[0])

--- a/tests/test_cp3h.py
+++ b/tests/test_cp3h.py
@@ -14,7 +14,7 @@ class CP3HMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "cp3h" and o.instant.step_is("12h")]
+        orders = [o for o in orders if o.recipe.name == "cp3h" and o.instant.step == "12h"]
         self.assertEqual(len(orders), 1)
 
         self.assertRenders(orders[0])

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -12,7 +12,7 @@ import numpy
 
 import arkimapslib.inputs
 from arkimapslib.config import Config
-from arkimapslib.inputs import Instant, Input
+from arkimapslib.inputs import Instant, Input, ModelStep
 from arkimapslib.pantry import Pantry, DiskPantry
 
 
@@ -211,6 +211,61 @@ class TestInputs(unittest.TestCase):
             self.assertEqual(inp.path, "testfile")
 
 
+class TestModelStep(unittest.TestCase):
+    def test_from_int(self):
+        ms = ModelStep(0)
+        self.assertEqual(str(ms), "0h")
+        ms = ModelStep(12)
+        self.assertEqual(str(ms), "12h")
+
+    def test_from_str(self):
+        ms = ModelStep("0h")
+        self.assertEqual(str(ms), "0h")
+
+        ms = ModelStep("12h")
+        self.assertEqual(str(ms), "12h")
+
+        with self.assertRaises(ValueError):
+            ms = ModelStep("30m")
+
+    def test_from_modelstep(self):
+        ms = ModelStep(ModelStep("0h"))
+        self.assertEqual(str(ms), "0h")
+
+        ms = ModelStep(ModelStep("12h"))
+        self.assertEqual(str(ms), "12h")
+
+    def test_equals(self):
+        ms = ModelStep(0)
+        self.assertEqual(ms, 0)
+        self.assertEqual(ms, "0h")
+        self.assertEqual(ms, ModelStep("0h"))
+        self.assertTrue(ms.is_zero())
+
+        ms = ModelStep(12)
+        self.assertEqual(ms, 12)
+        self.assertEqual(ms, "12h")
+        self.assertEqual(ms, ModelStep("12h"))
+        self.assertFalse(ms.is_zero())
+
+    def test_suffix(self):
+        ms = ModelStep(0)
+        self.assertEqual(ms.suffix(), "+000")
+        ms = ModelStep(12)
+        self.assertEqual(ms.suffix(), "+012")
+
+    def test_hashable(self):
+        steps = {
+            ModelStep(0),
+            ModelStep(12),
+        }
+        self.assertEqual(len(steps), 2)
+        self.assertEqual(steps, {
+            ModelStep(0),
+            ModelStep(12),
+        })
+
+
 class TestInstant(unittest.TestCase):
     def test_access(self):
         i = Instant(datetime.datetime(2023, 1, 1), 12)
@@ -229,8 +284,7 @@ class TestInstant(unittest.TestCase):
         self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 12).step_is("12h"))
 
         i = Instant(datetime.datetime(2023, 1, 1), 12)
-        with self.assertRaises(TypeError):
-            i.step_is(12)
+        self.assertTrue(i.step_is(12))
         with self.assertRaises(ValueError):
             i.step_is("720m")
         with self.assertRaises(ValueError):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -226,7 +226,13 @@ class TestModelStep(unittest.TestCase):
         self.assertEqual(str(ms), "12h")
 
         with self.assertRaises(ValueError):
-            ms = ModelStep("30m")
+            ModelStep("30m")
+        with self.assertRaises(ValueError):
+            ModelStep("43200s")
+        with self.assertRaises(ValueError):
+            ModelStep("")
+        with self.assertRaises(ValueError):
+            ModelStep("h")
 
     def test_from_modelstep(self):
         ms = ModelStep(ModelStep("0h"))
@@ -247,6 +253,15 @@ class TestModelStep(unittest.TestCase):
         self.assertEqual(ms, "12h")
         self.assertEqual(ms, ModelStep("12h"))
         self.assertFalse(ms.is_zero())
+
+        with self.assertRaises(ValueError):
+            ms == "720m"
+        with self.assertRaises(ValueError):
+            ms == "43200s"
+        with self.assertRaises(ValueError):
+            ms == ""
+        with self.assertRaises(ValueError):
+            ms == "h"
 
     def test_suffix(self):
         ms = ModelStep(0)
@@ -270,26 +285,8 @@ class TestInstant(unittest.TestCase):
     def test_access(self):
         i = Instant(datetime.datetime(2023, 1, 1), 12)
         self.assertEqual(i.reftime, datetime.datetime(2023, 1, 1))
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(i.step, 12)
+        self.assertEqual(i.step, 12)
 
         self.assertTrue(i == Instant(datetime.datetime(2023, 1, 1), 12))
         self.assertTrue(i != Instant(datetime.datetime(2023, 1, 1), 11))
         self.assertTrue(i != Instant(datetime.datetime(2023, 1, 2), 12))
-
-        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 0).step_is_zero())
-        self.assertFalse(Instant(datetime.datetime(2023, 1, 1), 24).step_is_zero())
-
-        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 0).step_is("0h"))
-        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 12).step_is("12h"))
-
-        i = Instant(datetime.datetime(2023, 1, 1), 12)
-        self.assertTrue(i.step_is(12))
-        with self.assertRaises(ValueError):
-            i.step_is("720m")
-        with self.assertRaises(ValueError):
-            i.step_is("43200s")
-        with self.assertRaises(ValueError):
-            i.step_is("")
-        with self.assertRaises(ValueError):
-            i.step_is("h")

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -209,3 +209,33 @@ class TestInputs(unittest.TestCase):
 
             self.assertEqual(inp.abspath, os.path.join(static_dir, "testfile"))
             self.assertEqual(inp.path, "testfile")
+
+
+class TestInstant(unittest.TestCase):
+    def test_access(self):
+        i = Instant(datetime.datetime(2023, 1, 1), 12)
+        self.assertEqual(i.reftime, datetime.datetime(2023, 1, 1))
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(i.step, 12)
+
+        self.assertTrue(i == Instant(datetime.datetime(2023, 1, 1), 12))
+        self.assertTrue(i != Instant(datetime.datetime(2023, 1, 1), 11))
+        self.assertTrue(i != Instant(datetime.datetime(2023, 1, 2), 12))
+
+        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 0).step_is_zero())
+        self.assertFalse(Instant(datetime.datetime(2023, 1, 1), 24).step_is_zero())
+
+        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 0).step_is("0h"))
+        self.assertTrue(Instant(datetime.datetime(2023, 1, 1), 12).step_is("12h"))
+
+        i = Instant(datetime.datetime(2023, 1, 1), 12)
+        with self.assertRaises(TypeError):
+            i.step_is(12)
+        with self.assertRaises(ValueError):
+            i.step_is("720m")
+        with self.assertRaises(ValueError):
+            i.step_is("43200s")
+        with self.assertRaises(ValueError):
+            i.step_is("")
+        with self.assertRaises(ValueError):
+            i.step_is("h")

--- a/tests/test_outputbundle.py
+++ b/tests/test_outputbundle.py
@@ -1,0 +1,44 @@
+# from __future__ import annotations
+import io
+import unittest
+
+from arkimapslib.inputs import ModelStep
+import arkimapslib.outputbundle as ob
+
+
+class TestOutputBundle(unittest.TestCase):
+    def test_add_products(self):
+        products = ob.Products(
+            summary=[
+                {
+                    "flavour": {
+                        "name": "flavour",
+                        "defined_in": "flavour.yaml",
+                    },
+                    "recipe": {
+                        "name": "recipe",
+                        "defined_in": "recipe.yaml",
+                        "description": "recipe description",
+                        "info": {},
+                    },
+                    "reftimes": {
+                        "2023-06-01 12:00:00": {
+                            "inputs": ["input1", "input2"],
+                            "steps": {
+                                str(ModelStep(12)): 3,
+                            },
+                            "legend_info": {},
+                            "render_stats": {
+                                "time_ns": 123_456_789_012,
+                            },
+                        }
+                    },
+                    "images": {
+                        "test/product": {"georef": {}},
+                    },
+                },
+            ]
+        )
+        with io.BytesIO() as buf:
+            with ob.Writer(out=buf) as writer:
+                writer.add_products(products)

--- a/tests/test_sf3h.py
+++ b/tests/test_sf3h.py
@@ -13,7 +13,7 @@ class SF3HCosmoMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == 12]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(
@@ -44,7 +44,7 @@ class SF3HNoConvMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == 12]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(
@@ -68,7 +68,7 @@ class SF3HIFSMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == 12]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(

--- a/tests/test_sf3h.py
+++ b/tests/test_sf3h.py
@@ -13,7 +13,7 @@ class SF3HCosmoMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == "12h"]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(
@@ -44,7 +44,7 @@ class SF3HNoConvMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == "12h"]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(
@@ -68,7 +68,7 @@ class SF3HIFSMixin:
 
         orders = self.make_orders()
         self.assertGreaterEqual(len(orders), 4)
-        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step_is("12h")]
+        orders = [o for o in orders if o.recipe.name == "sf3h" and o.instant.step == "12h"]
         self.assertEqual(len(orders), 1)
 
         self.assertProcessLogEqual(

--- a/tests/test_tp1h.py
+++ b/tests/test_tp1h.py
@@ -33,7 +33,7 @@ class TP1HMixin:
             return
         else:
             self.assertGreaterEqual(len(orders), 12)
-        orders = [o for o in orders if o.recipe.name == "tiles/tp1h" and o.instant.step == 12]
+        orders = [o for o in orders if o.recipe.name == "tiles/tp1h" and o.instant.step_is("12h")]
         self.assertEqual(len(orders), 1)
 
         self.assertRenders(orders[0])

--- a/tests/test_tp1h.py
+++ b/tests/test_tp1h.py
@@ -33,7 +33,7 @@ class TP1HMixin:
             return
         else:
             self.assertGreaterEqual(len(orders), 12)
-        orders = [o for o in orders if o.recipe.name == "tiles/tp1h" and o.instant.step_is("12h")]
+        orders = [o for o in orders if o.recipe.name == "tiles/tp1h" and o.instant.step == "12h"]
         self.assertEqual(len(orders), 1)
 
         self.assertRenders(orders[0])


### PR DESCRIPTION
This changes the type of `Instant.step` from an int to a `ModelStep` class, which can be extended to support measurement units. At the moment the only unit supported is `hour`.

It's a backwards-compatible changes, besides a change in the format of `products.json`, which should enable to introduce part-hour steps and hopefully also other kinds of step in the future.